### PR TITLE
Version std_dev

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,19 +2,22 @@ import flatliners
 import metrics
 
 if __name__ == '__main__':
-    metrics = metrics.FileMetrics()
+    metrics = metrics.FileMetrics() # this is an observable that streams in all the data alerts->etcd->build
 
     # subscribe versioned metrics, which adds the version to the metrics stream
     # to metrics. Every metric emitted by metrics is sent to versioned_metrics
-    versioned_metrics = flatliners.VersionedMetrics()
-    metrics.subscribe(versioned_metrics)
+    versioned_metrics = flatliners.VersionedMetrics() # initilizes an observer that operates on our data
+    metrics.subscribe(versioned_metrics) # creates versioned_metrics that adds version to etcd data
+    # versioned_metrics.subscribe(print) # print to prove
+
 
     # just 2 flatliners
-    std_dev_cluster = flatliners.StdDevCluster()
-    std_dev_version = flatliners.StdDevVersion()
+    std_dev_cluster = flatliners.StdDevCluster() # this is an observer that operates on some cluster data
+    std_dev_version = flatliners.StdDevVersion() # this is an obesrver that operates on some version data
 
     # one will get versioned metrics
-    versioned_metrics.subscribe(std_dev_cluster)
+    versioned_metrics.subscribe(std_dev_cluster) # take etcd data and perform std_dev_cluster operation
+    #std_dev_cluster.subscribe(print)
 
     # std_dev_cluster emits the std_dev for a cluster
     # this is something std_dev_version is interested in

--- a/flatliners/stddevcluster.py
+++ b/flatliners/stddevcluster.py
@@ -18,6 +18,7 @@ class StdDevCluster(BaseFlatliner):
         # grab the resource name and the cluster id
         resource = self.metric_label(x, 'resource')
         cluster_id = self.cluster_id(x)
+        version_id = self.metric_label(x,"gitVersion")
 
         # if cluster_id is not present add it as an empty dictionary
         if cluster_id not in self.clusters:
@@ -26,14 +27,14 @@ class StdDevCluster(BaseFlatliner):
         # if the resource hasen't been seen before, do std_dev initilization
         if resource not in self.clusters[cluster_id]:
             self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), resource,
-                                                                      cluster_id)
+                                                                      cluster_id, version_id)
 
-        # if the resource exists, grab the last entry for that cluster, resource pair.
+        # if the resource exists, grab the last entry for that cluster.
         # set the new value to the updated values.
         else:
             previous = self.clusters[cluster_id][resource]
             self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), resource,
-                                                                      cluster_id, previous)
+                                                                      cluster_id, version_id, previous)
 
         self.publish(self.clusters[cluster_id][resource])
 
@@ -51,7 +52,7 @@ class StdDevCluster(BaseFlatliner):
         return {'count': count, 'mean': v_sum / count}
 
     @staticmethod
-    def calculate_stdv(values, name, cluster, previous = None):
+    def calculate_stdv(values, name, cluster, version, previous = None):
         num_entires = len(values)
         if previous:
             for x in values:
@@ -91,6 +92,6 @@ class StdDevCluster(BaseFlatliner):
                 m2 = 0
 
         return {'cluster': cluster, 'resource': name, 'std_dev': std_dev, 'm2': m2, 'mean': mean,
-                'total': total, 'count': count}
+                'total': total, 'count': count, 'version': version}
 
 

--- a/flatliners/stddevcluster.py
+++ b/flatliners/stddevcluster.py
@@ -10,8 +10,7 @@ class StdDevCluster(BaseFlatliner):
     def on_next(self, x):
         """ update calculate std dev for cluster
         """
-        # print(f"got {x}")
-
+        # stop if the metric name is not etcd_object_count
         if not self.metric_name(x) == 'etcd_object_counts':
             return
 
@@ -22,10 +21,12 @@ class StdDevCluster(BaseFlatliner):
             self.clusters[cluster_id] = dict()
 
         if resource not in self.clusters[cluster_id]:
-            self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x))
+            #self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x))
+            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x))
         else:
             previous = self.clusters[cluster_id][resource]
-            self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x), previous)
+            #self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x), previous)
+            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), previous)
 
         self.publish(self.clusters[cluster_id][resource])
 
@@ -34,9 +35,32 @@ class StdDevCluster(BaseFlatliner):
         if previous:
             count = len(values) + previous['count']
             v_sum = previous['count'] * previous['mean']
+
         else:
             count = len(values)
             v_sum = 0
 
         v_sum += sum(int(x[1]) for x in values)
         return {'count': count, 'mean': v_sum / count}
+
+    @staticmethod
+    def calculate_stdv(values, previous = None):
+        if previous:
+
+            total = previous['total'] + int(values[0][0]) # I'm not 100% sure if this is the correct way to organize the data.
+            mean = total / len(values)
+            m2 = previous['m2'] + (int(values[0][0]) - previous['mean'])*(int(values[0][0]) - mean)
+            std_dev = (m2/(len(values)))**(0.5)
+
+
+        else:
+            # intilize values if there is not previous data.
+            std_dev = 0
+            m2 = 0
+            mean = int(values[0][0])
+            total = sum(int(x[1]) for x in values)
+
+
+        return {'std_dev': std_dev, 'm2' : m2, 'mean' : mean, 'total' : total}
+
+

--- a/flatliners/stddevcluster.py
+++ b/flatliners/stddevcluster.py
@@ -1,4 +1,5 @@
 from .baseflatliner import BaseFlatliner
+from statistics import stdev
 
 
 class StdDevCluster(BaseFlatliner):
@@ -14,19 +15,25 @@ class StdDevCluster(BaseFlatliner):
         if not self.metric_name(x) == 'etcd_object_counts':
             return
 
+        # grab the resource name and the cluster id
         resource = self.metric_label(x, 'resource')
         cluster_id = self.cluster_id(x)
 
+        # if cluster_id is not present add it as an empty dictionary
         if cluster_id not in self.clusters:
             self.clusters[cluster_id] = dict()
 
+        # if the resource hasen't been seen before, do std_dev initilization
         if resource not in self.clusters[cluster_id]:
-            #self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x))
-            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x))
+            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), resource,
+                                                                      cluster_id)
+
+        # if the resource exists, grab the last entry for that cluster, resource pair.
+        # set the new value to the updated values.
         else:
             previous = self.clusters[cluster_id][resource]
-            #self.clusters[cluster_id][resource] = self.calculate_mean(self.metric_values(x), previous)
-            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), previous)
+            self.clusters[cluster_id][resource] = self.calculate_stdv(self.metric_values(x), resource,
+                                                                      cluster_id, previous)
 
         self.publish(self.clusters[cluster_id][resource])
 
@@ -44,23 +51,46 @@ class StdDevCluster(BaseFlatliner):
         return {'count': count, 'mean': v_sum / count}
 
     @staticmethod
-    def calculate_stdv(values, previous = None):
+    def calculate_stdv(values, name, cluster, previous = None):
+        num_entires = len(values)
         if previous:
+            for x in values:
+                current_value = int(x[1])
+                current_count = previous['count'] + 1
+                current_total = previous['total'] + current_value
+                current_mean = current_total / current_count
 
-            total = previous['total'] + int(values[0][0]) # I'm not 100% sure if this is the correct way to organize the data.
-            mean = total / len(values)
-            m2 = previous['m2'] + (int(values[0][0]) - previous['mean'])*(int(values[0][0]) - mean)
-            std_dev = (m2/(len(values)))**(0.5)
+                m2 = previous['m2'] + (current_value - previous['mean'])*(current_value-current_mean)
+                std_dev = (m2/(current_count-1))**0.5
+
+                previous['count'] = current_count
+                previous['total'] = current_total
+                previous['mean'] = current_mean
+                previous['m2'] = m2
+                previous['std_dev'] = std_dev
+
+            count = current_count
+            mean = current_mean
+            total = current_total
+
 
 
         else:
             # intilize values if there is not previous data.
-            std_dev = 0
-            m2 = 0
-            mean = int(values[0][0])
-            total = sum(int(x[1]) for x in values)
+            count = num_entires
+            if num_entires > 1:
+                std_dev = stdev(int(x[1]) for x in values)
+                total = sum(int(x[1]) for x in values)
+                mean = total/num_entires
+                m2 = sum(((int(x[1])-mean)**2) for x in values)
 
+            else:
+                std_dev = 0
+                total = int(values[0][1])
+                mean = int(values[0][1])
+                m2 = 0
 
-        return {'std_dev': std_dev, 'm2' : m2, 'mean' : mean, 'total' : total}
+        return {'cluster': cluster, 'resource': name, 'std_dev': std_dev, 'm2': m2, 'mean': mean,
+                'total': total, 'count': count}
 
 

--- a/flatliners/stddevversion.py
+++ b/flatliners/stddevversion.py
@@ -5,11 +5,50 @@ class StdDevVersion(BaseFlatliner):
     def __init__(self):
         super().__init__()
 
+        self.versions = dict()
+
     def on_next(self, x):
         """ update std dev for version
         """
 
-        # print(f"got {x}")
-        std_dev = x
+        # stop if the metric name is not etcd_object_count
+        #if not self.metric_name(x) == 'etcd_object_counts':
+        #    return
 
-        self.publish(std_dev)
+        # grab the resource name and the version id
+        resource = x['resource']
+        version_id = x["version"]
+        value = x['std_dev']
+
+        # if version_id is not present add it as an empty dictionary
+        if version_id not in self.versions:
+            self.versions[version_id] = dict()
+
+        # if the resource hasen't been seen before, do std_dev initilization
+        if resource not in self.versions[version_id]:
+            self.versions[version_id][resource] = self.calculate_version_std(value, resource, version_id)
+
+        # if the resource exists, grab the last entry for that cluster, resource pair.
+        # set the new value to the updated values.
+        else:
+            previous = self.versions[version_id][resource]
+            self.versions[version_id][resource] = self.calculate_version_std(value, resource,
+                                                                       version_id, previous)
+
+        self.publish(self.versions[version_id][resource])
+
+
+    @staticmethod
+    def calculate_version_std(value, resource, version, previous = None):
+        if previous:
+            count = previous['count'] + 1
+            total = previous['total'] + value
+            version_std_dev = total/count
+
+        else:
+            # initilize version std_dev with output of first cluster
+            version_std_dev = value
+            count = 1
+            total = version_std_dev
+
+        return {'version': version, 'resource': resource, 'avg_std_dev': version_std_dev, 'count': count, 'total':total}


### PR DESCRIPTION
This pull request includes an update primarily to the class `StdDevVersion()` and includes the method `calculate_version_std()` that takes as input, the output of `calculate_stdv()` and calculates the running average of the std_dev value across all clusters with the same version_id  for each etcd resource 