### PR TITLE
Add buffering for resources

### DIFF
--- a/flatliners/comparisonscore.py
+++ b/flatliners/comparisonscore.py
@@ -25,7 +25,8 @@ class ComparisonScore(BaseFlatliner):
         if is_cluster_record:
             cluster_id = x['cluster']
             self.compute_cluster_distance(self.clusters, self.versions, x, self.score)
-            self.publish(self.score[cluster_id])
+            if self.ready_to_publish(x):
+                self.publish(self.score[cluster_id])
 
     @staticmethod
     def set_version_std(version_records, values):
@@ -55,3 +56,12 @@ class ComparisonScore(BaseFlatliner):
         # store final, single value for each cluster in scores.
         cluster_records[cluster_id][resource] = (value - version_records[version_id][resource])**2
         scores[cluster_id] = (sum(list(cluster_records[cluster_id].values())))**0.5
+
+    def ready_to_publish(self, x):
+        cluster_id = x['cluster']
+        resoure_name = x['resource']
+
+        if resoure_name in self.clusters[cluster_id].keys():
+            return True
+        else:
+            return False

--- a/flatliners/comparisonscore.py
+++ b/flatliners/comparisonscore.py
@@ -56,11 +56,11 @@ class ComparisonScore(BaseFlatliner):
         self.score[cluster_id] = {'cluster': cluster_id, 'score': (sum(list(self.clusters[cluster_id].values())))**0.5 }
 
 
-      def ready_to_publish(self, x):
-              cluster_id = x['cluster']
-              resoure_name = x['resource']
-
-              if resoure_name in self.clusters[cluster_id].keys():
-                  return True
-              else:
-                  return False
+    def ready_to_publish(self, x):
+          cluster_id = x['cluster']
+          resoure_name = x['resource']
+        
+          if resoure_name in self.clusters[cluster_id].keys():
+              return True
+          else:
+              return False


### PR DESCRIPTION
This PR adds a new method `wait_for_resources()' that prevents the data from being published until we have values for all 64 resources. 

Without this, the weirdness score seems to grow artificially rapidly over the the first 64 entries.  