### PR TITLE
timestamp to influx

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@ import os
 
 if __name__ == '__main__':
     metrics = metrics.FileMetrics() # this is an observable that streams in all the data alerts->etcd->build
-
     # subscribe versioned metrics, which adds the version to the metrics stream
     # to metrics. Every metric emitted by metrics is sent to versioned_metrics
     versioned_metrics = flatliners.VersionedMetrics() # initilizes an observer that operates on our data
@@ -44,8 +43,6 @@ if __name__ == '__main__':
     alert_cor.subscribe(corr_comparison_score)
 
     version_alert_corr.subscribe(corr_comparison_score)
-
-
 
     #corr_comparison_score.subscribe(print)
 

--- a/flatliners/clusteralertcorr.py
+++ b/flatliners/clusteralertcorr.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 import pandas as pd
+import time
 from datetime import datetime
 from itertools import combinations
 from .baseflatliner import BaseFlatliner
@@ -83,9 +84,11 @@ class ClusterAlertCorrelation(BaseFlatliner):
                     alert_combination_list.append('_'.join(elm))
                     alert_combination_value_list.append(val)
 
+                tuple_timestamp = time.mktime(self.timestamp.timetuple())
                 self.clusters_correlation[clust_id] = {'dataframe': pd.DataFrame(data = [alert_combination_value_list],
                                                                     columns = alert_combination_list),
-                                                       'version': version_id}
+                                                       'version': version_id,
+                                                       'timestamp': tuple_timestamp}
 
 
             self.publish(self.clusters_correlation)

--- a/flatliners/comparisonscore.py
+++ b/flatliners/comparisonscore.py
@@ -53,7 +53,8 @@ class ComparisonScore(BaseFlatliner):
         # and then take the square root of the sum to calculate the Euclidean distance between vectors.
         # store final, single value for each cluster in scores.
         self.clusters[cluster_id][resource] = (value - self.versions[version_id][resource])**2
-        self.score[cluster_id] = {'cluster': cluster_id, 'std_norm': (sum(list(self.clusters[cluster_id].values())))**0.5 }
+        self.score[cluster_id] = {'cluster': cluster_id, 'std_norm': (sum(list(self.clusters[cluster_id].values())))**0.5,
+                                  "timestamp": values["timestamp"]}
 
 
     def ready_to_publish(self, x):

--- a/flatliners/corrcomparison.py
+++ b/flatliners/corrcomparison.py
@@ -40,7 +40,8 @@ class CorrComparisonScore(BaseFlatliner):
                 if version_data.shape == cluster_data.shape:
                     # calculate distance
                     self.compute_cluster_distance(version_data, cluster_data, cluster_name)
-
+                    timestamp = self.clusters[cluster_name]['timestamp']
+                    self.score[cluster_name]["timestamp"] = timestamp
                     self.publish(self.score[cluster_name])
 
 

--- a/flatliners/influxdbstorage.py
+++ b/flatliners/influxdbstorage.py
@@ -2,6 +2,7 @@ from .baseflatliner import BaseFlatliner
 
 from influxdb import InfluxDBClient
 import os
+from datetime import datetime
 
 class InfluxdbStorage(BaseFlatliner):
     def __init__(self):
@@ -12,9 +13,11 @@ class InfluxdbStorage(BaseFlatliner):
         """ update l2 distance between cluster vector and baseline vector
         """
         client = InfluxDBClient(host=os.environ['FLT_INFLUX_HOST'], port=8086)
-        client.switch_database('flatliner')
+        client.switch_database('prometheus_flatliner')
+
         client.write_points([{"measurement": "clusterdata",
         "tags": {
             "clusterID": x['cluster']
         },
-        "fields": x}], time_precision='ms')
+        "time": datetime.utcfromtimestamp(x['timestamp_std']).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        "fields": x}])

--- a/flatliners/stddevcluster.py
+++ b/flatliners/stddevcluster.py
@@ -37,6 +37,7 @@ class StdDevCluster(BaseFlatliner):
                                                                       cluster_id, version_id, previous)
 
         self.normalize_cluster(cluster_id, resource)
+        self.clusters[cluster_id][resource]["timestamp"] = x["values"][0][0]
         self.publish(self.clusters[cluster_id][resource])
 
     @staticmethod

--- a/flatliners/weirdnessscore.py
+++ b/flatliners/weirdnessscore.py
@@ -11,22 +11,22 @@ class WeirdnessScore(BaseFlatliner):
     def on_next(self, x):
 
         cluster_name = x['cluster']
-        #self.publish(x)
 
         if cluster_name not in self.score:
             self.score[cluster_name] = dict()
             self.score[cluster_name]['cluster'] = cluster_name
 
         if list(x.keys())[1] == 'corr_norm':
-            self.score[cluster_name]['corr'] = x['corr_norm']
-
+            self.score[cluster_name]['corr'] = float(x['corr_norm'])
+            self.score[cluster_name]['timestamp_corr'] = float(x["timestamp"])
 
 
         if list(x.keys())[1] == 'std_norm':
-            self.score[cluster_name]['std_dev'] = x['std_norm']
+            self.score[cluster_name]['std_dev'] = float(x['std_norm'])
+            self.score[cluster_name]['timestamp_std'] = float(x['timestamp'])
 
 
-        if len(list(self.score[cluster_name].keys()))>=3:
+        if len(list(self.score[cluster_name].keys()))>=5:
             self.score[cluster_name]['sum'] = self.score[cluster_name]['corr'] \
                                             + self.score[cluster_name]['std_dev']
 


### PR DESCRIPTION
This PR make a few minor changes to the cluster processors to ensure that the time stamp provided by Prometheus is retained and sent to influxdb with the appropriate output data.    