### PR TITLE
Flatten Input Arrays

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,39 +32,35 @@ def main():
     comparison_score = flatliners.ComparisonScore()
     corr_comparison_score = flatliners.CorrComparisonScore()
 
+    single_value_metric = flatliners.SingleValueMetric()
+    versioned_metrics.subscribe(single_value_metric)
+
     # one will get versioned metrics
-    versioned_metrics.subscribe(std_dev_cluster)  # take etcd data and perform std_dev_cluster operation
+    # take etcd data and perform std_dev_cluster operation
+    single_value_metric.subscribe(std_dev_cluster)
     std_dev_cluster.subscribe(std_dev_version)
 
     # std_dev_cluster emits the std_dev for a cluster
     # this is something std_dev_version is interested in
-
     std_dev_cluster.subscribe(comparison_score)
     std_dev_version.subscribe(comparison_score)
 
     # Alert correlation
     alert_cor = flatliners.ClusterAlertCorrelation()
-    versioned_metrics.subscribe(alert_cor)
-    # alert_cor.subscribe(print) # this emits a df with the correlation values for a single cluster
+    single_value_metric.subscribe(alert_cor)
 
     # Git version alert correlation
     version_alert_corr = flatliners.GitVersionAlertCorrelation()
-
-    versioned_metrics.subscribe(version_alert_corr)
-
-    # version_alert_corr.subscribe(print) # this emits a df with correlation values for a gitVersion
+    single_value_metric.subscribe(version_alert_corr)
 
     alert_cor.subscribe(corr_comparison_score)
-
     version_alert_corr.subscribe(corr_comparison_score)
-
-    # corr_comparison_score.subscribe(print)
 
     weirdness_score = flatliners.WeirdnessScore()
     comparison_score.subscribe(weirdness_score)
     corr_comparison_score.subscribe(weirdness_score)
 
-    # weirdness_score.subscribe(print)
+    weirdness_score.subscribe(print)
 
     score_sum = 0
     def add_scores(value):

--- a/flatliners/__init__.py
+++ b/flatliners/__init__.py
@@ -8,3 +8,4 @@ from .gitversionalertcorr import GitVersionAlertCorrelation
 from .corrcomparison import CorrComparisonScore
 from .weirdnessscore import WeirdnessScore
 from .influxdbstorage import InfluxdbStorage
+from .singlevaluemetric import SingleValueMetric

--- a/flatliners/singlevaluemetric.py
+++ b/flatliners/singlevaluemetric.py
@@ -1,0 +1,13 @@
+from .baseflatliner import BaseFlatliner
+
+class SingleValueMetric(BaseFlatliner):
+
+    def __init__(self):
+        super().__init__()
+
+    def on_next(self, x):
+
+        for value in x['values']:
+            single_value_metric = x
+            single_value_metric['values'] = [value]
+            self.publish(single_value_metric)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,4 +5,4 @@ class TestApp():
 
     def test_metric_label(self):
         score_sum = app.main()
-        assert score_sum == 9185.497109006963
+        assert score_sum == 104258.41245185716


### PR DESCRIPTION
This PR adds a new processor `singlevaluemetric` that flattens the Prometheus packet arrays coming from `versionedmetrics` so that only one timestamp value pair is processed at a time.

  