### PR TITLE
Add live metric delay to deployment template, Makefile and PromMetricsLive class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ oc_live_deploy:
 		--param FLT_METRIC_CHUNK_SIZE="${FLT_METRIC_CHUNK_SIZE}" \
 		--param FLT_INFLUX_DB_DSN="${FLT_INFLUX_DB_DSN}" \
 		--param FLT_LIVE_METRIC_COLLECT="True" \
+		--param FLT_LIVE_METRIC_DELAY="${FLT_LIVE_METRIC_DELAY}" \
 		| oc apply -f -
 
 oc_delete_live_deployment:

--- a/metrics/prommetrics.py
+++ b/metrics/prommetrics.py
@@ -21,6 +21,7 @@ class PromMetrics:
         self.metric_end_datetime = metric_end_datetime
         self.metric_chunk_size = metric_chunk_size
         self.final_packet_timestamp = dict()
+        self.final_packet_timestamp[0] = 0
 
     def subscribe(self, observer):
         self.observable.subscribe(observer)

--- a/metrics/prommetricslive.py
+++ b/metrics/prommetricslive.py
@@ -21,9 +21,9 @@ class PromMetricsLive:
         self.metric_end_datetime = os.getenv('FLT_LIVE_METRIC_DELAY','now')
         self.metric_chunk_size = metric_chunk_size
         self.trigger_interval_secs = int(round((dateparser.parse('now') - dateparser.parse(self.metric_chunk_size)).total_seconds()))
-        self.metric_start_datetime = str(self.trigger_interval_secs + int(round((dateparser.parse('now') - dateparser.parse(self.metric_end_datetime)).total_seconds()))) + 's' #'3m' # should be (metric_chunk_size + metric_end_datetime)
+        self.metric_start_datetime = str(self.trigger_interval_secs + int(round((dateparser.parse('now') - dateparser.parse(self.metric_end_datetime)).total_seconds()))) + 's' 
         self.prev_pkt_end_time = self.metric_start_datetime
-        
+
     def subscribe(self, observer):
         self.observable.subscribe(observer)
 

--- a/openshift/prometheus-flatliner-live-deployment-template.yaml
+++ b/openshift/prometheus-flatliner-live-deployment-template.yaml
@@ -43,8 +43,9 @@ parameters:
   description: The URL to connect to an influx database
   required: true
 - name: FLT_LIVE_METRIC_DELAY
-  description: The URL to connect to an influx database
-  required: true
+  description: The rolling delay while collecting live metrics (now = no delay, 5m = 5 minutes of delay) 
+  value: 'now'
+  required: false
 - name: FLT_DEBUG_MODE
   description: Enable verbose log for debugging
   value: 'False'

--- a/openshift/prometheus-flatliner-live-deployment-template.yaml
+++ b/openshift/prometheus-flatliner-live-deployment-template.yaml
@@ -42,6 +42,9 @@ parameters:
 - name: FLT_INFLUX_DB_DSN
   description: The URL to connect to an influx database
   required: true
+- name: FLT_LIVE_METRIC_DELAY
+  description: The URL to connect to an influx database
+  required: true
 - name: FLT_DEBUG_MODE
   description: Enable verbose log for debugging
   value: 'False'
@@ -136,6 +139,8 @@ objects:
             value: "${FLT_LIVE_METRIC_COLLECT}"
           - name: FLT_INFLUX_DB_DSN
             value: "${FLT_INFLUX_DB_DSN}"
+          - name: FLT_LIVE_METRIC_DELAY
+            value: "${FLT_LIVE_METRIC_DELAY}"
           - name: FLT_DEBUG_MODE
             value: "${FLT_DEBUG_MODE}"
           image: ${APPLICATION_NAME}


### PR DESCRIPTION
This feature lets you specify a time delay in metric collection using an env variable (FLT_LIVE_METRIC_DELAY) when in live metric collection mode.

Until now the live metric collection queried Prometheus for data including the current time, but Prometheus might not have polled that data yet from the targets. So with this rolling delay, the app will query prometheus for data 5 minutes earlier than the current time (when delay = 5m).

For example, if you run the app with delay = 5m and chunk size = 10m, and the app sends a query to prometheus at 03:05, it will query for data between 02:50 and 03:00, instead of data between 02:55 and 03:05. 

Why?
Because at 03:05, the metric data for 03:05 might not yet be in Prometheus' database, and in the next iteration of queries 03:05 might be skipped. So using the delay will prevent missing values.

To not use the delay, unset the env variable (FLT_LIVE_METRIC_DELAY) or set it to 'now'
