### PR TITLE
Update app.py to include alert data in 'weirdness_score' flatliner

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,13 +72,16 @@ def main():
 
     weirdness_score = flatliners.WeirdnessScore()
     comparison_score.subscribe(weirdness_score)
+    alert_comparison.subscribe(weirdness_score)
 
     # weirdness_score.subscribe(print)
 
     score_sum = 0
+
     def add_scores(value):
         nonlocal score_sum
-        score_sum = score_sum + value.std_dev
+        if isinstance(value, flatliners.weirdnessscore.WeirdnessScore.Resource_State):
+            score_sum = score_sum + value.std_dev
 
     weirdness_score.subscribe(add_scores)
 

--- a/flatliners/weirdnessscore.py
+++ b/flatliners/weirdnessscore.py
@@ -40,7 +40,7 @@ class WeirdnessScore(BaseFlatliner):
             self.alert_score[cluster_name].alert = x.alert
             self.alert_score[cluster_name].weirdness_score = x.comparison_score
             self.alert_score[cluster_name].timestamp = float(x.timestamp)
-            self.alert_score[cluster_name].resource_deltas = x.resource_deltas
+            self.alert_score[cluster_name].alert_deltas = x.alert_deltas
 
             self.publish(self.alert_score[cluster_name])
 


### PR DESCRIPTION
This PR relates to #65. 

Fixed bug in `weirdnessscore.py` for storing the alert frequency data. 

Updated app.py so that the alert frequency data is consumed by the `weirdness_score` flatliner and pushed to influxdb  