### PR TITLE
Update influxstorage.py to reduce number of resource deltas on each write

### DIFF
--- a/flatliners/influxdbstorage.py
+++ b/flatliners/influxdbstorage.py
@@ -34,7 +34,20 @@ class InfluxdbStorage(BaseFlatliner):
                     }
                 })
 
-            self.add_resource_metrics(x)
+            self.buffer_list.append({
+                "measurement": "resource_deltas",
+                "tags": {
+                    "cluster_id": x.cluster,
+                    "cluster_version": x.version,
+                    "resource_type": x.resource
+                },
+                "time": datetime.utcfromtimestamp(x.std_dev_timestamp).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                "fields": {
+                    "resource_deltas": x.resource_deltas[x.resource]
+
+                }
+            })
+
 
         if isinstance(x, flatliners.weirdnessscore.WeirdnessScore.Alert_Sate):
             # add weirdness score
@@ -74,20 +87,3 @@ class InfluxdbStorage(BaseFlatliner):
         self.client.write_points(self.buffer_list)
         self.buffer_list = []
 
-    def add_resource_metrics(self, x):
-
-        resources = list(x.resource_deltas.keys())
-        for resource in resources:
-            self.buffer_list.append({
-                "measurement": "resource_deltas",
-                "tags": {
-                    "cluster_id": x.cluster,
-                    "cluster_version": x.version,
-                    "resource_type": resource
-                },
-                "time": datetime.utcfromtimestamp(x.std_dev_timestamp).strftime('%Y-%m-%dT%H:%M:%SZ'),
-                "fields": {
-                    "resource_deltas": x.resource_deltas[resource]
-
-                }
-            })

--- a/flatliners/resourcecomparisonscore.py
+++ b/flatliners/resourcecomparisonscore.py
@@ -60,6 +60,7 @@ class ResourceComparisonScore(BaseFlatliner):
         state = self.State()
         state.cluster = cluster_id
         state.version = values.version
+        state.resource = values.resource
         state.std_norm = (sum(list(self.clusters[cluster_id].values())))**0.5
         state.timestamp = values.timestamp
         state.resource_deltas = self.resource_deltas[cluster_id]
@@ -80,6 +81,7 @@ class ResourceComparisonScore(BaseFlatliner):
 
         cluster: str = ""
         version: str = ""
+        resource: str = ""
         std_norm: float = 0.0
         timestamp:float = 0.0
         resource_deltas: str = ""

--- a/flatliners/weirdnessscore.py
+++ b/flatliners/weirdnessscore.py
@@ -25,6 +25,7 @@ class WeirdnessScore(BaseFlatliner):
             self.resource_score[cluster_name].std_dev_timestamp = float(x.timestamp)
             self.resource_score[cluster_name].std_dev_buffer = True
             self.resource_score[cluster_name].version = version
+            self.resource_score[cluster_name].resource = x.resource
             self.resource_score[cluster_name].resource_deltas = x.resource_deltas
 
             if self.resource_score[cluster_name].std_dev_buffer:
@@ -51,6 +52,7 @@ class WeirdnessScore(BaseFlatliner):
 
         cluster: str = ""
         version: str = ""
+        resource: str = ""
         std_dev: float = 0.0
         std_dev_timestamp: float = 0.0
         weirdness_score:float = 0.0


### PR DESCRIPTION
This PR modifies `influxstorage.py` by reducing the number of resource deltas being pushed to influx on each `write_points`.

The effect of this is that we can much more quickly write to influx without changing the resource delta values.    