### PR TITLE
Update alert frequncy to running average of alert frequencies

### DIFF
--- a/flatliners/alertcomparisonscore.py
+++ b/flatliners/alertcomparisonscore.py
@@ -44,7 +44,7 @@ class AlertComparisonScore(BaseFlatliner):
     def update_cluster_alerts(self,x):
         if x.cluster not in self.clusters:
             self.clusters[x.cluster] = dict()
-        self.clusters[x.cluster][x.alert] = x.frequency
+        self.clusters[x.cluster][x.alert] = x.avg_frequency
 
     def initialize_metric_state(self,x):
         state = self.State()

--- a/flatliners/alertfrequencycluster.py
+++ b/flatliners/alertfrequencycluster.py
@@ -64,6 +64,20 @@ class AlertFrequencyCluster(BaseFlatliner):
         self.clusters[cluster_id][alert_name].frequency = float(len(self.clusters[cluster_id]
                                                              [alert_name].time_stamps))
 
+        previous =  self.clusters[cluster_id][alert_name]
+        self.update_harmonic_mean(previous)
+
+
+    def update_harmonic_mean(self,previous):
+
+        frequency = previous.frequency
+        current_count = previous.count + 1
+        current_total = previous.total + (1.0/frequency)
+        previous.avg_frequency = current_count/current_total
+        previous.count = current_count
+        previous.total = current_total
+        self.clusters[previous.cluster][previous.alert] = previous
+
 
     def normalize_cluster(self, cluster_id, alert):
         # get the values:
@@ -95,5 +109,8 @@ class AlertFrequencyCluster(BaseFlatliner):
         alert: str = ""
         version: str = ""
         frequency: float = 0.0
+        avg_frequency: float = 0.0
         timestamp: float = 0.0
         time_stamps: str = ""
+        total: float = 0.0
+        count:  float = 0.0

--- a/flatliners/alertfrequencyversion.py
+++ b/flatliners/alertfrequencyversion.py
@@ -42,7 +42,7 @@ class AlertFrequencyVersion(BaseFlatliner):
         state.alert = x.alert
         state.version = x.version
         state.cluster_frequencies = {x.cluster : x.frequency}
-        state.avg_frequency = x.frequency
+        state.avg_frequency = x.avg_frequency
         state.timestamp = x.timestamp
         self.version_frequencies[x.version][x.alert] = state
 
@@ -50,7 +50,7 @@ class AlertFrequencyVersion(BaseFlatliner):
     def update_version_alert(self,x,previous):
 
         # update cluster frequency
-        previous.cluster_frequencies[x.cluster] = x.frequency
+        previous.cluster_frequencies[x.cluster] = x.avg_frequency
         # compute average frequency
         previous_values = list(previous.cluster_frequencies.values())
         previous.avg_frequency = sum(previous_values) / float(len(previous_values))


### PR DESCRIPTION
This PR updates the core calculation for the Alert Frequency flatliners. Now, instead of outputting the frequency of alerts for the current 30 minute time window, it produces a moving average of alert frequencies over all data seen.   