### PR TITLE
Add a flatliner to filter metrics by OCP version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ FLT_METRIC_CHUNK_SIZE=1h
 FLT_LIVE_METRIC_COLLECT=False
 FTL_INFLUX_DB_DSN=influxdb://username:password@localhost:8086/databasename
 NAMESPACE=aiops-prod-prometheus-lts
+FLT_VERSION_FILTER_REGEX="^[0-9]*\.[0-9]*\.[0-9]*-[0-9]*\.[0-9]*$"

--- a/app.py
+++ b/app.py
@@ -54,7 +54,16 @@ def main():
     alert_comparison = flatliners.AlertComparisonScore()
 
     single_value_metric = flatliners.SingleValueMetric()
-    versioned_metrics.subscribe(single_value_metric)
+
+    # Check if the feature flag for Version filter is set
+    if os.getenv("FLT_VERSION_FILTER_REGEX"):
+        version_regex = os.getenv("FLT_VERSION_FILTER_REGEX")
+        version_filtered_metrics = flatliners.VersionFilter(version_regex=version_regex)
+        versioned_metrics.subscribe(version_filtered_metrics)
+        version_filtered_metrics.subscribe(single_value_metric)
+    else:
+        # if flag is not set, bypass the filter
+        versioned_metrics.subscribe(single_value_metric)
 
     single_value_metric.subscribe(alert_freq_cluster)
     alert_freq_cluster.subscribe(alert_freq_version)

--- a/flatliners/__init__.py
+++ b/flatliners/__init__.py
@@ -10,3 +10,4 @@ from .weirdnessscore import WeirdnessScore
 from .influxdbstorage import InfluxdbStorage
 from .singlevaluemetric import SingleValueMetric
 from .prometheusendpoint import PrometheusEndpoint
+from .versionfilter import VersionFilter

--- a/flatliners/prometheusendpoint.py
+++ b/flatliners/prometheusendpoint.py
@@ -28,7 +28,7 @@ class PrometheusEndpoint(BaseFlatliner):
             # Store timestamp when the metric was published and metric version info
             self.published_metric_timestamps[str(x.cluster)] = [int(time()),str(x.version)]
         except Exception as e:
-            _LOGGER.error("Couldn't process the following packet {0}. Reason: {1}".format(x,str(e)))
+            _LOGGER.error("Couldn't process the following packet {0}. Reason: {1}".format(x, str(e)))
             raise e
 
     def _delete_stale_metrics(self):
@@ -46,7 +46,9 @@ class PrometheusEndpoint(BaseFlatliner):
 
     def start_server(self):
         # Start http server to expose metrics
-        start_http_server(8000)
+        http_server_port = 8000
+        start_http_server(http_server_port)
+        _LOGGER.info("http server started on port {0}".format(http_server_port))
         while True:
             # delete stale exposed metrics
             self._delete_stale_metrics()

--- a/flatliners/versionfilter.py
+++ b/flatliners/versionfilter.py
@@ -1,0 +1,27 @@
+'''
+Rx module to filter metrics based on their version
+'''
+import logging
+import regex as re
+
+from .baseflatliner import BaseFlatliner
+
+# Set up logging
+_LOGGER = logging.getLogger(__name__)
+
+
+
+class VersionFilter(BaseFlatliner):
+    '''
+    Rx module to filter metrics based on their version
+    '''
+    def __init__(self, version_regex):
+        super().__init__()
+        # create a regex pattern from the specified expression
+        self.version_regex_pattern = re.compile(version_regex)
+        _LOGGER.info("Version filter initialized with regex espression: %s", version_regex)
+
+    def on_next(self, x):
+        if self.version_regex_pattern.match(str(x["metric"]["version"])):
+            # if the version matches the regex pattern publish it
+            self.publish(x)

--- a/openshift/prometheus-flatliner-deployment-template.yaml
+++ b/openshift/prometheus-flatliner-deployment-template.yaml
@@ -38,6 +38,9 @@ parameters:
 - name: FLT_INFLUX_DB_DSN
   description: The URL to connect to an influx database
   required: false
+- name: FLT_VERSION_FILTER_REGEX
+  description: Regex expression to filter for metrics based on version info, eg. '^4\.0'
+  required: false
 - name: FLT_LIVE_METRIC_DELAY
   description: The rolling delay while collecting live metrics (now = no delay, 5m = 5 minutes of delay)
   value: 'now'
@@ -136,6 +139,8 @@ objects:
             value: "${FLT_INFLUX_DB_DSN}"
           - name: FLT_LIVE_METRIC_DELAY
             value: "${FLT_LIVE_METRIC_DELAY}"
+          - name: FLT_VERSION_FILTER_REGEX
+            value: "${FLT_VERSION_FILTER_REGEX}"
           - name: FLT_DEBUG_MODE
             value: "${FLT_DEBUG_MODE}"
           image: ${APPLICATION_NAME}

--- a/openshift/prometheus-flatliner-job-template.yaml
+++ b/openshift/prometheus-flatliner-job-template.yaml
@@ -43,6 +43,8 @@ objects:
             value: "${FLT_METRIC_END_DATETIME}"
           - name: FLT_METRIC_CHUNK_SIZE
             value: "${FLT_METRIC_CHUNK_SIZE}"
+          - name: FLT_VERSION_FILTER_REGEX
+            value: "${FLT_VERSION_FILTER_REGEX}"
           - name: FLT_INFLUX_DB_DSN
             value: "${FLT_INFLUX_DB_DSN}"
           - name: FLT_DEBUG_MODE
@@ -81,4 +83,7 @@ parameters:
 - name: FLT_DEBUG_MODE
   description: Enable verbose log for debugging
   value: 'False'
+  required: false
+- name: FLT_VERSION_FILTER_REGEX
+  description: Regex expression to filter for metrics based on version info, eg. '^4\.0'
   required: false


### PR DESCRIPTION
#83 Add VersionFilter flatliner class that filters metrics by OCP version info, based on a Regex expression (Specified using env variable: `FLT_VERSION_FILTER_REGEX`). 
Also add the flags in oc deployment and job templates.